### PR TITLE
fix chart release action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Chart Publish
 on:
   push:
     branches:
-      - master
+      - main
       - rewrite-build
 jobs:
   publish:

--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,7 @@
 # See: https://go.k8s.io/owners
 approvers:
 - stormgbs
+- eahydra
 reviewers:
 - stormgbs
+- eahydra


### PR DESCRIPTION
Signed-off-by: Tao Li <joseph.t.lee@outlook.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/koordinator-sh/koordinator/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
