### PR TITLE
fix: add rbac roles on topology.node.k8s.io

### DIFF
--- a/versions/v0.5.0/templates/rbac_role.yaml
+++ b/versions/v0.5.0/templates/rbac_role.yaml
@@ -161,6 +161,7 @@ rules:
 - apiGroups:
   - config.koordinator.sh
   - slo.koordinator.sh
+  - topology.node.k8s.io
   resources:
   - "*"
   verbs:
@@ -213,6 +214,7 @@ rules:
   - apiGroups:
       - config.koordinator.sh
       - slo.koordinator.sh
+      - topology.node.k8s.io
     resources:
       - '*'
     verbs:
@@ -286,6 +288,7 @@ rules:
 - apiGroups:
   - config.koordinator.sh
   - slo.koordinator.sh
+  - topology.node.k8s.io
   resources:
   - "*"
   verbs:


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#versioning)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/koordinator-sh/koordinator/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
