### PR TITLE
change volume path to value

### DIFF
--- a/versions/v0.7.0/templates/koordlet.yaml
+++ b/versions/v0.7.0/templates/koordlet.yaml
@@ -32,7 +32,7 @@ spec:
           - -runtime-hooks=AllAlpha=true
           - -runtime-hooks-network=unix
           - -runtime-hooks-addr=/host-var-run-koordlet/koordlet.sock
-          - -runtime-hooks-host-endpoint={{ .Values.koordlet.volume.hostVarRunKoordlet }}koordlet.sock
+          - -runtime-hooks-host-endpoint={{ .Values.koordlet.hostDirs.koordletSockDir }}/koordlet.sock
           - --logtostderr=true
           - --v={{ .Values.koordlet.log.level }}
           image: {{ .Values.imageRepositoryHost }}/{{ .Values.koordlet.image.repository }}:{{ .Values.koordlet.image.tag }}
@@ -103,7 +103,7 @@ spec:
             type: ""
           name: host-var-run
         - hostPath:
-            path: {{ .Values.koordlet.volume.hostVarRunKoordlet }}
+            path: {{ .Values.koordlet.hostDirs.koordletSockDir }}
             type: "DirectoryOrCreate"
           name: host-var-run-koordlet
         - hostPath:
@@ -111,14 +111,14 @@ spec:
             type: ""
           name: host-sys
         - hostPath:
-            path: {{ .Values.koordlet.volume.hostKubernetes }}
+            path: {{ .Values.koordlet.hostDirs.kubeletConfigDir }}
             type: ""
           name: host-kubernetes
         - hostPath:
-            path: {{ .Values.koordlet.volume.hostHookServer }}
+            path: {{ .Values.koordlet.hostDirs.koordProxyRegisterDir }}
             type: ""
           name: host-etc-hookserver
         - hostPath:
-            path: {{ .Values.koordlet.volume.hostKubeletRootdir }}
+            path: {{ .Values.koordlet.hostDirs.kubeletLibDir }}
             type: ""
           name: host-kubelet-rootdir

--- a/versions/v0.7.0/templates/koordlet.yaml
+++ b/versions/v0.7.0/templates/koordlet.yaml
@@ -32,6 +32,7 @@ spec:
           - -runtime-hooks=AllAlpha=true
           - -runtime-hooks-network=unix
           - -runtime-hooks-addr=/host-var-run-koordlet/koordlet.sock
+          - -runtime-hooks-host-endpoint={{ .Values.koordlet.volume.hostVarRunKoordlet }}koordlet.sock
           - --logtostderr=true
           - --v={{ .Values.koordlet.log.level }}
           image: {{ .Values.imageRepositoryHost }}/{{ .Values.koordlet.image.repository }}:{{ .Values.koordlet.image.tag }}
@@ -102,7 +103,7 @@ spec:
             type: ""
           name: host-var-run
         - hostPath:
-            path: /var/run/koordlet/
+            path: {{ .Values.koordlet.volume.hostVarRunKoordlet }}
             type: "DirectoryOrCreate"
           name: host-var-run-koordlet
         - hostPath:
@@ -110,14 +111,14 @@ spec:
             type: ""
           name: host-sys
         - hostPath:
-            path: /etc/kubernetes/
+            path: {{ .Values.koordlet.volume.hostKubernetes }}
             type: ""
           name: host-kubernetes
         - hostPath:
-            path: /etc/runtime/hookserver.d/
+            path: {{ .Values.koordlet.volume.hostHookServer }}
             type: ""
           name: host-etc-hookserver
         - hostPath:
-            path: /var/lib/kubelet
+            path: {{ .Values.koordlet.volume.hostKubeletRootdir }}
             type: ""
           name: host-kubelet-rootdir

--- a/versions/v0.7.0/values.yaml
+++ b/versions/v0.7.0/values.yaml
@@ -29,11 +29,11 @@ koordlet:
   log:
     # log level for koordlet
     level: "4"
-  volume:
-    hostKubernetes: /etc/kubernetes/
-    hostKubeletRootdir: /var/lib/kubelet
-    hostHookServer: /etc/runtime/hookserver.d/
-    hostVarRunKoordlet: /var/run/koordlet/
+  hostDirs:
+    kubeletConfigDir: /etc/kubernetes/
+    kubeletLibDir: /var/lib/kubelet/
+    koordProxyRegisterDir: /etc/runtime/hookserver.d/
+    koordletSockDir: /var/run/koordlet/
 
 
 manager:

--- a/versions/v0.7.0/values.yaml
+++ b/versions/v0.7.0/values.yaml
@@ -29,6 +29,12 @@ koordlet:
   log:
     # log level for koordlet
     level: "4"
+  volume:
+    hostKubernetes: /etc/kubernetes/
+    hostKubeletRootdir: /var/lib/kubelet
+    hostHookServer: /etc/runtime/hookserver.d/
+    hostVarRunKoordlet: /var/run/koordlet/
+
 
 manager:
   # settings for log print


### PR DESCRIPTION
This PR is to solve issue #40 for change volume path to values.
Basically some host volume path should be able to config by users so make it as a value. Also make it a value if it can be used in koordlet args. 


Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/koordinator-sh/koordinator/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
