### PR TITLE
change koordlet feature-gate config

### DIFF
--- a/versions/v1.1.0/templates/koordlet.yaml
+++ b/versions/v1.1.0/templates/koordlet.yaml
@@ -29,7 +29,8 @@ spec:
             - /koordlet
           args:
           - -cgroup-root-dir=/host-cgroup/
-          - -feature-gates=AllAlpha=true,PerformanceCollector=false
+          - -feature-gates=BECPUEvict=true,BEMemoryEvict=true,CgroupReconcile=true,Accelerators=true
+          # other feature-gates enabled by default include BECPUSuppress, CPUBurst, RdtResctrl and NodeTopologyReport
           - -runtime-hooks=AllAlpha=true
           - -runtime-hooks-network=unix
           - -runtime-hooks-addr=/host-var-run-koordlet/koordlet.sock


### PR DESCRIPTION
The default config value of some koordlet feature-gates has been modified in previous source code commit. This PR is to change the way that we config feature-gates in helm charts. 

For most feature-gates we just follow the default value in source code, while for others that are set as `false` but are often used we open it explicitly as container args such as `BECPUEvict`, `BEMemoryEvict`, etc. 

Also notice that feature-gate of Koordlet collector `PerformanceCollector` is already marked as `deprecated` in some previous commits, and was noticed to the community that we will delete it in v1.1.0.to `CPICollector`, and add new `PSICollector` into it. Here we also follow the default config in source code, which is `false`.

Signed-off-by: songtao98 <songtao2603060@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/koordinator-sh/koordinator/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
