### PR TITLE
koordlet: Add koordlet servicemonitor with control

### DIFF
--- a/versions/v1.1.0/templates/koordlet-service.yaml
+++ b/versions/v1.1.0/templates/koordlet-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    koord-app: koordlet
+  name: koordlet-service
+  namespace: {{ .Values.installation.namespace }}
+spec:
+  clusterIP: None
+  ports:
+  # TODO: Support port in values
+  - name: http
+    port: 9316
+    targetPort: 9316
+  selector:
+    koord-app: koordlet

--- a/versions/v1.1.0/templates/koordlet-service.yaml
+++ b/versions/v1.1.0/templates/koordlet-service.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.koordlet.enableServiceMonitor }}
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +16,5 @@ spec:
     targetPort: 9316
   selector:
     koord-app: koordlet
+
+{{- end }}

--- a/versions/v1.1.0/templates/koordlet-servicemonitor.yaml
+++ b/versions/v1.1.0/templates/koordlet-servicemonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    koord-app: koordlet
+  name: koordlet-service-monitor
+  namespace: {{ .Values.installation.namespace }}
+spec:
+  endpoints:
+  - interval: 30s
+    port: http
+    relabelings:
+    - action: replace
+      regex: (.*)
+      replacement: $1
+      sourceLabels:
+      - __meta_kubernetes_pod_node_name
+      targetLabel: node
+    scheme: http
+  jobLabel: koord-app
+  selector:
+    matchLabels:
+      koord-app: koordlet

--- a/versions/v1.1.0/templates/koordlet-servicemonitor.yaml
+++ b/versions/v1.1.0/templates/koordlet-servicemonitor.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.koordlet.enableServiceMonitor }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -21,3 +23,5 @@ spec:
   selector:
     matchLabels:
       koord-app: koordlet
+
+{{- end }}

--- a/versions/v1.1.0/values.yaml
+++ b/versions/v1.1.0/values.yaml
@@ -34,6 +34,7 @@ koordlet:
     kubeletLibDir: /var/lib/kubelet/
     koordProxyRegisterDir: /etc/runtime/hookserver.d/
     koordletSockDir: /var/run/koordlet
+  enableServiceMonitor: false
 
 
 manager:


### PR DESCRIPTION
Add service monitor for koordlet metrics evicted through prometheus. Use value to control whether to install or not. 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/koordinator-sh/koordinator/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
