### PR TITLE
add a default clustercolocation crd

### DIFF
--- a/versions/v1.2.0/templates/koord-clustercolocation.yaml
+++ b/versions/v1.2.0/templates/koord-clustercolocation.yaml
@@ -1,0 +1,26 @@
+apiVersion: config.koordinator.sh/v1alpha1
+kind: ClusterColocationProfile
+metadata:
+  name: colocation-profile-example
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # clusterColocationProfile is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+spec:
+  namespaceSelector:
+    matchLabels:
+      koordinator.sh/enable-colocation: "true"
+  selector:
+    matchLabels:
+      koordinator.sh/enable-colocation: "true"
+  qosClass: BE
+  priorityClassName: koord-batch
+  koordinatorPriority: 1000
+  schedulerName: koord-scheduler
+  labels:
+    koordinator.sh/mutated: "true"
+  annotations:
+    koordinator.sh/intercepted: "true"
+  patch:
+    spec:
+      terminationGracePeriodSeconds: 30


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/koordinator-sh/koordinator/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
