### PR TITLE
add runtimeClassName and nodeAffinity for koordlet

### DIFF
--- a/versions/v1.3.0/README.md
+++ b/versions/v1.3.0/README.md
@@ -51,6 +51,8 @@ The following table lists the configurable parameters of the chart and their def
 | `koordlet.resources.limits.memory`        | Memory resource limit of koordlet container                      | `256Mi`                         |
 | `koordlet.resources.requests.cpu`         | CPU resource request of koordlet container                       | `0`                             |
 | `koordlet.resources.requests.memory`      | Memory resource request of koordlet container                    | `0`                             |
+| `koordlet.runtimeClassName`               | Specify runtimeClassName, like `nvidia`                          | ``                              |
+| `koordlet.nodeAffinity`                   | Specify affinity to allow koordlet be scheduled to certain nodes | `{}`                            |
 | `webhookConfiguration.failurePolicy.pods` | The failurePolicy for pods in mutating webhook configuration     | `Ignore`                        |
 | `webhookConfiguration.timeoutSeconds`     | The timeoutSeconds for all webhook configuration                 | `30`                            |
 | `crds.managed`                            | Koordinator will not install CRDs with chart if this is false    | `true`                          |

--- a/versions/v1.3.0/templates/koordlet.yaml
+++ b/versions/v1.3.0/templates/koordlet.yaml
@@ -95,6 +95,13 @@ spec:
               name: metric-db-path
       tolerations:
         - operator: Exists
+{{- if .Values.koordlet.runtimeClassName }}
+      runtimeClassName: {{ .Values.koordlet.runtimeClassName }}
+{{- end }}
+{{- if .Values.koordlet.nodeAffinity }}
+      affinity:
+        {{- toYaml .Values.koordlet.nodeAffinity | nindent 8 }}
+{{- end }}
       hostNetwork: true
       hostPID: true
       terminationGracePeriodSeconds: 10

--- a/versions/v1.3.0/values.yaml
+++ b/versions/v1.3.0/values.yaml
@@ -39,7 +39,8 @@ koordlet:
     # if not specified, use tmpfs by default
     koordletTSDBDir: ""
   enableServiceMonitor: false
-
+  runtimeClassName: ""
+  nodeAffinity: {}
 
 manager:
   # settings for log print


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/koordinator-sh/koordinator/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.

---

Please kindly do a review. I am running a k3s cluster, 1 master node, 2 worker (with containerd, see example agent config. when specifying default runtime in /etc/docker/daemon.json, it's working.) nodes with GPU cards. 
- I need to specify runtimeClassName to allow the GPU cards be discovered. Otherwise `kubectl get devices` will return an empty list.
- I need to specify node nodeAffinity to allow koordlet could be scheduled to worker nodes only.

After above modifications, I am seeing the expected output from `kubectl get devices`.

```bash
user@k3s81:~# kubectl get devices -o yaml
apiVersion: v1
items:
- apiVersion: scheduling.koordinator.sh/v1alpha1        
  kind: Device
  metadata:
    creationTimestamp: "2023-10-15T07:12:40Z"
    generation: 1
    labels:
      node.koordinator.sh/gpu-driver-version: 535.104.12
      node.koordinator.sh/gpu-model: GeForce-RTX-2080-Ti
    name: k3s82
    ownerReferences:
    - apiVersion: v1
      blockOwnerDeletion: true
      controller: true
      kind: Node
      name: k3s82
      uid: 42b37e92-e079-466d-ab18-a00ce2187cf3
    resourceVersion: "10140"
    uid: 3e24800e-7cfb-4c96-8a4f-d2eca3fef5a1
  spec:
    devices:
    - health: true
      id: GPU-ebca0fd7-1821-8765-3239-ca056e15b028      
      minor: 0
      resources:
        koordinator.sh/gpu-core: "100"
        koordinator.sh/gpu-memory: 11Gi
        koordinator.sh/gpu-memory-ratio: "100"
      type: gpu
  status: {}
- apiVersion: scheduling.koordinator.sh/v1alpha1
  kind: Device
  metadata:
    creationTimestamp: "2023-10-15T07:12:40Z"
    generation: 1
    labels:
      node.koordinator.sh/gpu-driver-version: 535.104.12
      node.koordinator.sh/gpu-model: GeForce-RTX-2080-Ti
    name: k3s83
    ownerReferences:
    - apiVersion: v1
      blockOwnerDeletion: true
      controller: true
      kind: Node
      name: k3s83
      uid: a09e5037-42fa-4868-b061-89af3d4951bb
    resourceVersion: "10139"
    uid: 8ff8e0a7-f557-4d9e-8e30-345d2341fb90
  spec:
    devices:
    - health: true
      id: GPU-7e738f84-ca39-bce7-3107-73ba51a16e9b
      minor: 0
      resources:
        koordinator.sh/gpu-core: "100"
        koordinator.sh/gpu-memory: 11Gi
        koordinator.sh/gpu-memory-ratio: "100"
      type: gpu
  status: {}
kind: List
metadata:
  resourceVersion: ""
```

```yaml
# https://github.com/k3s-io/k3s/issues/1264#issuecomment-903821584
token: TOKEN
server: https://k3s81:6443
docker: false
kubelet-arg:
  - "node-status-update-frequency=4s"
private-registry: "/etc/rancher/k3s/registry.yaml"
flannel-iface: "ens193"
log: "/var/log/k3s-agent.log"
```