### PR TITLE
fix failurePolicy not found when NodeValidatingWebhook enabled

### DIFF
--- a/versions/v1.4.0/README.md
+++ b/versions/v1.4.0/README.md
@@ -52,6 +52,9 @@ The following table lists the configurable parameters of the chart and their def
 | `koordlet.resources.requests.cpu`         | CPU resource request of koordlet container                       | `0`                             |
 | `koordlet.resources.requests.memory`      | Memory resource request of koordlet container                    | `0`                             |
 | `webhookConfiguration.failurePolicy.pods` | The failurePolicy for pods in mutating webhook configuration     | `Ignore`                        |
+| `webhookConfiguration.failurePolicy.elasticquotas` | The failurePolicy for elasticQuotas in all webhook configuration              | `Ignore`                        |
+| `webhookConfiguration.failurePolicy.nodeStatus` | The failurePolicy for node.status in all webhook configuration              | `Ignore`                        |
+| `webhookConfiguration.failurePolicy.nodes` | The failurePolicy for nodes in all webhook configuration              | `Ignore`                        |
 | `webhookConfiguration.timeoutSeconds`     | The timeoutSeconds for all webhook configuration                 | `30`                            |
 | `crds.managed`                            | Koordinator will not install CRDs with chart if this is false    | `true`                          |
 | `imagePullSecrets`                        | The list of image pull secrets for koordinator image             | `false`                         |

--- a/versions/v1.4.0/values.yaml
+++ b/versions/v1.4.0/values.yaml
@@ -80,6 +80,7 @@ webhookConfiguration:
     pods: Ignore
     elasticquotas: Ignore
     nodeStatus: Ignore
+    nodes: Ignore
   timeoutSeconds: 30
 
 serviceAccount:


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/koordinator-sh/koordinator/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
