### PR TITLE
add podminitor for scheduler & descheduler

### DIFF
--- a/versions/v1.8.0/README.md
+++ b/versions/v1.8.0/README.md
@@ -44,6 +44,7 @@ The following table lists the configurable parameters of the chart and their def
 | `scheduler.nodeAffinity`                           | Node affinity policy for koord-scheduler pod                     | `{}`                            |
 | `scheduler.nodeSelector`                           | Node labels for koord-scheduler pod                              | `{}`                            |
 | `scheduler.tolerations`                            | Tolerations for koord-scheduler pod                              | `[]`                            |
+| `scheduler.monitorEnabled`                         | Whether to enable PodMonitor for koord-scheduler                 | `false`                         |
 | `scheduler.hostNetwork`                            | Whether koord-scheduler pod should run with hostnetwork          | `false`                         |
 | `koordlet.log.level`                               | Log level that koordlet printed                                  | `4`                             |
 | `koordlet.image.repository`                        | Repository for koordlet image                                    | `koordinatorsh/koordlet`        |
@@ -71,6 +72,7 @@ The following table lists the configurable parameters of the chart and their def
 | `descheduler.nodeAffinity`                         | Node affinity policy for koord-descheduler pod                   | `{}`                            |
 | `descheduler.nodeSelector`                         | Node labels for koord-descheduler pod                            | `{}`                            |
 | `descheduler.tolerations`                          | Tolerations for koord-descheduler pod                            | `[]`                            |
+| `descheduler.monitorEnabled`                       | Whether to enable PodMonitor for koord-descheduler               | `false`                         |
 | `descheduler.hostNetwork`                          | Whether koord-descheduler pod should run with hostnetwork        | `false`                         |
 | `deviceDaemon.log.level`                           | Log level that koord-device-daemon printed                       | `4`                             |
 | `deviceDaemon.image.repository`                    | Repository for koord-device-daemon image                         | `koordinatorsh/koord-device-daemon` |

--- a/versions/v1.8.0/templates/koord-descheduler.yaml
+++ b/versions/v1.8.0/templates/koord-descheduler.yaml
@@ -41,6 +41,10 @@ spec:
             httpGet:
               path: healthz
               port: {{ .Values.descheduler.port }}
+          ports:
+            - containerPort: {{ .Values.descheduler.port }}
+              name: metrics
+              protocol: TCP
           resources:
             {{- toYaml .Values.descheduler.resources | nindent 12 }}
       hostNetwork: {{ .Values.descheduler.hostNetwork }}

--- a/versions/v1.8.0/templates/koord-scheduler.yaml
+++ b/versions/v1.8.0/templates/koord-scheduler.yaml
@@ -51,6 +51,10 @@ spec:
             httpGet:
               path: healthz
               port: {{ .Values.scheduler.port }}
+          ports:
+            - containerPort: {{ .Values.scheduler.port }}
+              name: metrics
+              protocol: TCP
           resources:
             {{- toYaml .Values.scheduler.resources | nindent 12 }}
       hostNetwork: {{ .Values.scheduler.hostNetwork }}

--- a/versions/v1.8.0/templates/pod-monitors
+++ b/versions/v1.8.0/templates/pod-monitors
@@ -1,0 +1,43 @@
+{{- if and .Values.descheduler.monitorEnabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: koord-descheduler-metrics-podmonitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    koord-app: koord-descheduler
+spec:
+  selector:
+    matchLabels:
+      koord-app: koord-descheduler
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - interval: 30s
+      path: /metrics
+      port: metrics
+{{- end }}
+
+{{- if and .Values.scheduler.monitorEnabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: koord-scheduler-metrics-podmonitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    koord-app: koord-scheduler
+spec:
+  selector:
+    matchLabels:
+      koord-app: koord-scheduler
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - interval: 30s
+      path: /metrics
+      port: metrics
+{{- end }}

--- a/versions/v1.8.0/values.yaml
+++ b/versions/v1.8.0/values.yaml
@@ -24,7 +24,7 @@ crds:
 installation:
   namespace: koordinator-system
   roleListGroups:
-    - '*'
+  - '*'
 
 featureGates: ""
 
@@ -62,7 +62,6 @@ koordlet:
   metrics:
     port: 9316
   enableServiceMonitor: false
-
 
 manager:
   # settings for log print
@@ -111,7 +110,6 @@ webhookConfiguration:
 serviceAccount:
   annotations: {}
 
-
 scheduler:
   # settings for log print
   log:
@@ -146,6 +144,7 @@ scheduler:
   nodeAffinity: {}
   nodeSelector: {}
   tolerations: []
+  monitorEnabled: false
 
 descheduler:
   # settings for log print
@@ -175,6 +174,7 @@ descheduler:
   nodeAffinity: {}
   nodeSelector: {}
   tolerations: []
+  monitorEnabled: false
 
 deviceDaemon:
   image:


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/koordinator-sh/koordinator/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
