### PR TITLE
fix: hami-daemon service type not configurable, promote v0.2.0

### DIFF
--- a/charts/hami-daemon
+++ b/charts/hami-daemon
@@ -1,1 +1,1 @@
-../hami-daemon/v0.1.0/
+../hami-daemon/v0.2.0/

--- a/hami-daemon/v0.2.0/Chart.yaml
+++ b/hami-daemon/v0.2.0/Chart.yaml
@@ -13,9 +13,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.2.0"
+annotations:
+  artifacthub.io/changes: |
+    - "[Fixed]: service type not configurable due to incorrect values path in service.yaml"
+    - "[Added]: initContainer to set /tmp/vgpulock permissions before hami-core starts"

--- a/hami-daemon/v0.2.0/templates/service.yaml
+++ b/hami-daemon/v0.2.0/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     koord-app: hami-daemon
   {{- include "hami-daemon.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.daemon.type }}
+  type: {{ .Values.daemon.vgpuMonitor.type }}
   selector:
     koord-app: hami-daemon
     {{- include "hami-daemon.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
## PR description
  Two related bugs in the `hami-daemon` chart fixed together as v0.2.0:

  **Fix 1 — service type not configurable**

  `templates/service.yaml` referenced `.Values.daemon.type` which doesn't exist in `values.yaml`. The `type` field lives under `daemon.vgpuMonitor.type`. Because Helm renders a missing key as an  empty string, the Service always got `type: ` regardless of what the user set, making NodePort/ LoadBalancer impossible to configure.

  **Fix 2 — v0.2.0 Chart.yaml version was still 0.1.0**

  `hami-daemon/v0.2.0/Chart.yaml` was copied from v0.1.0 and never updated — version and appVersion were both still `0.1.0`. The `charts/hami-daemon` pointer also still pointed at v0.1.0.   v0.2.0 adds an initContainer that fixes `/tmp/vgpulock` permissions, which is a real improvement,
  but it couldn't be published with the wrong version field.


Fixes #113 

Checklist:

  * [x] I have bumped the chart version according to [versioning](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#versioning)
  * [x] I have updated the chart changelog with all the changes that come with this pull request according to
  [changelog](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#changelog).
  * [x] Any new values are backwards compatible and/or have sensible default.

