### PR TITLE
fix: koordinator-yarn-copilot replicas hardcoded and metrics.addr missing from values

### DIFF
--- a/koordinator-yarn-copilot/v0.1.0/Chart.yaml
+++ b/koordinator-yarn-copilot/v0.1.0/Chart.yaml
@@ -2,5 +2,9 @@ apiVersion: v2
 name: koordinator-yarn-copilot
 description: A Helm chart for colocation k8s with hadoop yarn.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
+annotations:
+  artifacthub.io/changes: |
+    - "[Fixed]: deployment replicas hardcoded, now respects koordYarnOperator.replicas in values"
+    - "[Fixed]: metrics.addr missing from values.yaml, add field to allow bind address override"

--- a/koordinator-yarn-copilot/v0.1.0/templates/yarn-operator.yaml
+++ b/koordinator-yarn-copilot/v0.1.0/templates/yarn-operator.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     koord-app: koord-yarn-operator
 spec:
-  replicas: 2
+  replicas: {{ .Values.koordYarnOperator.replicas }}
   selector:
     matchLabels:
       koord-app: koord-yarn-operator

--- a/koordinator-yarn-copilot/v0.1.0/values.yaml
+++ b/koordinator-yarn-copilot/v0.1.0/values.yaml
@@ -13,6 +13,7 @@ koordYarnOperator:
     repository: koordinator-sh/yarn-operator
     tag: "v0.1.0"
   metrics:
+    addr: ""
     port: 8080
 
   resyncPeriod: "0"


### PR DESCRIPTION

 ## PR description:
  Two values.yaml inconsistencies in `koordinator-yarn-copilot/v0.1.0`:

  **Fix 1 — deployment replicas ignore values**

  `templates/yarn-operator.yaml` had `replicas: 2` hardcoded. `values.yaml` has a `koordYarnOperator.replicas` field but the template never referenced it, so  `--set koordYarnOperator.replicas=1` had no effect.

  **Fix 2 — metrics.addr used in template but absent from values.yaml**

  Line 41 of `yarn-operator.yaml` builds `--metrics-addr={{ .Values.koordYarnOperator.metrics.addr }}:{{ .Values.koordYarnOperator.metrics.port }}` but `metrics.addr` was not in `values.yaml`. The bind address always rendered as `:8080` and could not be overridden. Added `addr: ""` to match the pattern used by `koord-manager` in the main koordinator chart.

Fixes #114 

  Checklist:

  * [x] I have bumped the chart version according to [versioning](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#versioning)
  * [x] I have updated the chart changelog with all the changes that come with this pull request according to
  [changelog](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#changelog).
  * [x] Any new values are backwards compatible and/or have sensible default.
