### PR TITLE
allow disabling creation of various components

### DIFF
--- a/versions/v1.8.0/templates/gpu-shared-resource-templates.yaml
+++ b/versions/v1.8.0/templates/gpu-shared-resource-templates.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deviceDaemon.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -160,3 +161,4 @@ data:
         huawei.com/npu-cpu: "4"
         huawei.com/npu-dvpp: "100"
         koordinator.sh/gpu-memory: 16Gi
+{{- end }}

--- a/versions/v1.8.0/templates/koord-descheduler-config.yaml
+++ b/versions/v1.8.0/templates/koord-descheduler-config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.descheduler.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -68,3 +69,4 @@ data:
           highThresholds:
             cpu: 75
             memory: 80
+{{- end }}

--- a/versions/v1.8.0/templates/koord-descheduler.yaml
+++ b/versions/v1.8.0/templates/koord-descheduler.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.descheduler.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -85,3 +86,4 @@ spec:
 {{ toYaml .Values.descheduler.tolerations | indent 8 }}
 {{- end }}
 
+{{- end }}

--- a/versions/v1.8.0/templates/koord-device-daemon.yaml
+++ b/versions/v1.8.0/templates/koord-device-daemon.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deviceDaemon.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -87,3 +88,4 @@ spec:
             path: /dev/
             type: ""
           name: host-dev
+{{- end }}

--- a/versions/v1.8.0/templates/koord-manager.yaml
+++ b/versions/v1.8.0/templates/koord-manager.yaml
@@ -58,6 +58,7 @@ spec:
             - --feature-gates={{ .Values.featureGates }}
             - --sync-period={{ .Values.manager.resyncPeriod }}
             - --config-namespace={{ .Values.installation.namespace }}
+            - --controllers={{ .Values.manager.controllers }}
           command:
             - /koord-manager
           image: "{{ .Values.imageRepositoryHost }}/{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"

--- a/versions/v1.8.0/templates/koord-scheduler-config.yaml
+++ b/versions/v1.8.0/templates/koord-scheduler-config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -159,3 +160,4 @@ data:
             enabled:
               - name: Coscheduling
         schedulerName: koord-scheduler
+{{- end }}

--- a/versions/v1.8.0/templates/koord-scheduler.yaml
+++ b/versions/v1.8.0/templates/koord-scheduler.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -95,3 +96,4 @@ spec:
 {{ toYaml .Values.scheduler.tolerations | indent 8 }}
 {{- end }}
 
+{{- end }}

--- a/versions/v1.8.0/templates/koordlet.yaml
+++ b/versions/v1.8.0/templates/koordlet.yaml
@@ -39,7 +39,7 @@ spec:
           - -runtime-hooks-host-endpoint={{ .Values.koordlet.hostDirs.koordletSockDir }}/koordlet.sock
           - --logtostderr=true
           - --v={{ .Values.koordlet.log.level }}
-          image: "{{ .Values.imageRepositoryHost }}/{{ .Values.koordlet.image.repository }}:{{ .Values.koordlet.image.tag }}"
+          image: "{{ default .Values.imageRepositoryHost .Values.koordlet.image.host }}/{{ .Values.koordlet.image.repository }}:{{ .Values.koordlet.image.tag }}"
           imagePullPolicy: Always
           name: koordlet
           env:

--- a/versions/v1.8.0/templates/pod-monitors
+++ b/versions/v1.8.0/templates/pod-monitors
@@ -1,4 +1,4 @@
-{{- if and .Values.descheduler.monitorEnabled }}
+{{- if and .Values.descheduler.enabled .Values.descheduler.monitorEnabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -20,7 +20,7 @@ spec:
       port: metrics
 {{- end }}
 
-{{- if and .Values.scheduler.monitorEnabled }}
+{{- if and .Values.scheduler.enabled .Values.scheduler.monitorEnabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/versions/v1.8.0/templates/rbac/koordlet.yaml
+++ b/versions/v1.8.0/templates/rbac/koordlet.yaml
@@ -32,6 +32,7 @@ rules:
   - nodes
   - nodes/status
   - nodes/proxy
+  - nodes/finalizers
   - pods
   - pods/status
   - persistentvolumeclaims

--- a/versions/v1.8.0/values.yaml
+++ b/versions/v1.8.0/values.yaml
@@ -34,6 +34,7 @@ imagePullSecrets: {}
 
 koordlet:
   image:
+    host: registry.cn-beijing.aliyuncs.com
     repository: koordinator-sh/koordlet
     tag: "v1.8.0"
   resources:
@@ -64,6 +65,7 @@ koordlet:
   enableServiceMonitor: false
 
 manager:
+  controllers: 'nodemetric,noderesource,nodeslo,profile,colocationprofile'
   # settings for log print
   log:
     # log level for koord-manager
@@ -111,6 +113,7 @@ serviceAccount:
   annotations: {}
 
 scheduler:
+  enabled: true
   # settings for log print
   log:
     # log level for koord-scheduler
@@ -155,6 +158,7 @@ scheduler:
   monitorEnabled: false
 
 descheduler:
+  enabled: true
   # settings for log print
   log:
     # log level for koord-descheduler
@@ -185,6 +189,7 @@ descheduler:
   monitorEnabled: false
 
 deviceDaemon:
+  enabled: true
   image:
     repository: koordinator-sh/koord-device-daemon
     tag: "v1.8.0"


### PR DESCRIPTION
The MR is mainly created to allow disabling components. It also adds a few missing features, including:
- `nodes/finalizers` access to koordlet's cluster role. This is required for creating `noderesourcetopologies`.
- Allow modifying the image host of koordlet.
- Allow passing values for the `controllers` flag of koord-manager.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/koordinator-sh/charts/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/koordinator-sh/koordinator/blob/master/CODE_OF_CONDUCT.md).